### PR TITLE
Make to Work with CMake 4 and Fix Warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 2.8.8...3.10.0)
 
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -39,7 +39,7 @@ else()
   cmake_policy(SET CMP0048 NEW)
   project(gmock VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
 endif()
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 2.6.4...3.10.0)
 
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -46,7 +46,7 @@ else()
   cmake_policy(SET CMP0048 NEW)
   project(gtest VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
 endif()
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 2.6.4...3.10.0)
 
 if (POLICY CMP0063) # Visibility
   cmake_policy(SET CMP0063 NEW)

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -238,7 +238,13 @@ function(cxx_executable name dir libs)
 endfunction()
 
 # Sets PYTHONINTERP_FOUND and PYTHON_EXECUTABLE.
-find_package(PythonInterp)
+if(CMAKE_VERSION VERSION_LESS 3.27)
+  find_package(PythonInterp)
+else()
+  find_package(Python)
+  set(PYTHONINTERP_FOUND "${Python_FOUND}")
+  set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
+endif()
 
 # cxx_test_with_flags(name cxx_flags libs srcs...)
 #

--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -1212,14 +1212,14 @@ static int ExecDeathTestChildMain(void* child_arg) {
 static void StackLowerThanAddress(const void* ptr,
                                   bool* result) GTEST_NO_INLINE_;
 static void StackLowerThanAddress(const void* ptr, bool* result) {
-  int dummy;
+  int dummy = 0;
   *result = (&dummy < ptr);
 }
 
 // Make sure AddressSanitizer does not tamper with the stack here.
 GTEST_ATTRIBUTE_NO_SANITIZE_ADDRESS_
 static bool StackGrowsDown() {
-  int dummy;
+  int dummy = 0;
   bool result;
   StackLowerThanAddress(&dummy, &result);
   return result;


### PR DESCRIPTION
- CMake 4.0 removed compatibility with CMake 3.5. By default, CMake will now fail to build this version of GoogleTest without claiming to work with a newer version either in `cmake_minimum_required` or by forcing it using `CMAKE_POLICY_VERSION_MINIMUM`. Claim to work with up to CMake 3.10 because otherwise it warns about that.

- Fixed CMake warning for finding Python by changing to newer `find_package`.

- Took fixes for uninitialized variables build warnings from latest GoogleTest source: https://github.com/google/googletest/blob/52204f78f94d7512df1f0f3bea1d47437a2c3a58/googletest/src/gtest-death-test.cc#L1234-L1242